### PR TITLE
Adding gunicorn support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.15
 ARG PLEX_URL
 ARG PLEX_TOKEN
+ARG PORT=5000
 ARG STREAMABLE_LOGIN
 ARG STREAMABLE_PASSWORD
 RUN apk --no-cache add build-base
@@ -12,12 +13,16 @@ RUN apk --no-cache add py-pip
 RUN cd /usr/bin \
   && ln -sf python3.9 python
 ENV TZ=America/New_York
+ENV FLASK_DEBUG=0
+ENV FLASK_ENV=production
 ENV PLEX_URL=$PLEX_URL
 ENV PLEX_TOKEN=$PLEX_TOKEN
+ENV PORT=$PORT
 ENV STREAMABLE_LOGIN=$STREAMABLE_LOGIN
 ENV STREAMABLE_PASSWORD=$STREAMABLE_PASSWORD
+EXPOSE $PORT
 COPY . /app
 WORKDIR /app
 RUN pip install -r requirements.txt
 RUN set FLASK_APP=main.py
-CMD flask run --host 0.0.0.0
+CMD gunicorn wsgi:app

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,5 @@
+from multiprocessing import cpu_count
+from os import environ
+
+bind = "0.0.0.0:" + environ.get("PORT", "5000")
+workers = cpu_count()

--- a/main.py
+++ b/main.py
@@ -1,1 +1,0 @@
-from app import app

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask_wtf==0.14.3
 jinja2==3.0
 Werkzeug==2.0.0
 ffmpeg-python==0.2.0
+gunicorn==20.1.0

--- a/wsgi.py
+++ b/wsgi.py
@@ -1,0 +1,7 @@
+from os import environ
+
+from app import app
+
+
+if __name__ == "__main__":
+    app.run(debug=bool(environ.get("FLASK_DEBUG", True)))


### PR DESCRIPTION
Saw the plan for gunicorn support. This should take care of the basics. A few notes:

* The port is configurable via environment variable but defaults to 5000.
* Flask debug/env are now also configurable and default to production/no debug.
* gunicorn will spin up as many workers as there are cores detected. This could be made configurable, or you could limit the number of threads in `gunicorn.conf.py`. (Odds are a tool like this doesn't need more than one or two threads, but I'm just setting to the max as an example.)

Here's my runtime log showing the app loading from gunicorn:

```
[2022-07-27 17:19:16 -0600] [1] [INFO] Starting gunicorn 20.1.0
[2022-07-27 17:19:16 -0600] [1] [INFO] Listening at: http://0.0.0.0:5000 (1)
[2022-07-27 17:19:16 -0600] [1] [INFO] Using worker: sync
[2022-07-27 17:19:16 -0600] [7] [INFO] Booting worker with pid: 7
[2022-07-27 17:19:16 -0600] [8] [INFO] Booting worker with pid: 8
[2022-07-27 17:19:16 -0600] [9] [INFO] Booting worker with pid: 9
[2022-07-27 17:19:16 -0600] [10] [INFO] Booting worker with pid: 10
```

I got an unrelated runtime error after this, so you may want to double-check this in your own testing environment just in case, but gunicorn was loading the app successfully.