### PR TITLE
Increase crf to 20 to reduce video size

### DIFF
--- a/clipplexAPI.py
+++ b/clipplexAPI.py
@@ -161,7 +161,7 @@ class Video:
                     vcodec="libx264", 
                     acodec="libvorbis", 
                     pix_fmt="yuv420p", 
-                    crf=18, 
+                    crf=20, 
                     **{"metadata:g:0":f"title={self.metadata_title}", 
                     "metadata:g:1":f"season_number={self.metadata_season}", 
                     "metadata:g:2":f"show={self.metadata_showname}",


### PR DESCRIPTION
I don't know if the base repo is still maintained, but here's a small change to reduce the created mp4's size. Changing crf from 18 to 20 reduced the generated 15s test mp4 from 11 MB to 8.4 MB. 