### PR TITLE
Add subtitle mvp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ RUN apk --no-cache add ffmpeg
 RUN apk --no-cache add python3
 RUN apk --no-cache add python3-dev
 RUN apk --no-cache add py-pip
+RUN apk --no-cache add fontconfig ttf-freefont font-noto terminus-font \ 
+  && fc-cache -f \ 
+  && fc-list | sort 
 RUN cd /usr/bin \
   && ln -sf python3.9 python
 ENV TZ=America/New_York

--- a/app/routes.py
+++ b/app/routes.py
@@ -39,17 +39,18 @@ def create_video():
     _pad_time = clipplexAPI.Utils()._pad_time
     start = f"{_pad_time(args.get('start_hour'))}:{_pad_time(args.get('start_minute'))}:{_pad_time(args.get('start_second'))}"
     end = f"{_pad_time(args.get('end_hour'))}:{_pad_time(args.get('end_minute'))}:{_pad_time(args.get('end_second'))}"
-    result = get_instant_video(args.get('username'), start, end)
+    subs = args.get('subs')
+    result = get_instant_video(args.get('username'), start, end, subs)
     return jsonify(result)
 
-def get_instant_video(username, start, end):
+def get_instant_video(username, start, end, subs):
     plex_data = clipplexAPI.PlexInfo(username)
     clip_time = clipplexAPI.Utils().calculate_clip_time(start, end)
     media_name = plex_data.media_title.replace(" ", "")
     file_name = f"{username}_{media_name}_{int(time.time())}"
     current_media_time = plex_data.current_media_time_str
     print(f"Creating video of {clip_time} seconds starting at {start} for user {username} for file {plex_data.media_path}")
-    video = clipplexAPI.Video(plex_data, start, clip_time, file_name)
+    video = clipplexAPI.Video(plex_data, start, clip_time, file_name, subs)
     video.extract_video()
     return {"result":"success"}
 

--- a/app/templates/instant_video.html
+++ b/app/templates/instant_video.html
@@ -58,6 +58,9 @@
             {{ form.end_time_sec(id="end_second", size=2, placeholder="SS", maxlength=2)  }}
           </td>
         </tr>
+        <tr>
+          <input type="checkbox" id="subtitles" /> Subtitles (Will take way longer)
+        </tr>
       </table>
       <br>
       <!--
@@ -172,8 +175,9 @@
     var end_hour = document.getElementById("end_hour").value
     var end_minute = document.getElementById("end_minute").value
     var end_second = document.getElementById("end_second").value
+    var subs = document.getElementById("subtitles").checked
     const Http = new XMLHttpRequest();
-    const url="/create_video?username="+username+"&start_hour="+start_hour+"&start_minute="+start_minute+"&start_second="+start_second+"&end_hour="+end_hour+"&end_minute="+end_minute+"&end_second="+end_second
+    const url="/create_video?username="+username+"&start_hour="+start_hour+"&start_minute="+start_minute+"&start_second="+start_second+"&end_hour="+end_hour+"&end_minute="+end_minute+"&end_second="+end_second+"&subs="+subs
     Http.open("POST", url, true)
     $('#layoutSidenav').css({'filter': 'blur(8px)', '-webkit-filter': 'blur(8px)'})
     $('body').append('<div style="" id="loadingDiv"><div class="loader"></div><div class="loaderSecondLine">Creating video...</div></div>');

--- a/clipplexAPI.py
+++ b/clipplexAPI.py
@@ -155,13 +155,16 @@ class Video:
     def extract_video(self):
         (
             ffmpeg
-            .input(self.media_path, ss=self.time, t=self.duration)
-            .output(f"{MEDIA_STATIC_PATH}/videos/{self.file_name}.mp4", 
+            .input(self.media_path)
+            .output(f"{MEDIA_STATIC_PATH}/videos/{self.file_name}.mp4",
+                    ss=self.time,
+                    t=self.duration, 
                     map_metadata=-1, 
                     vcodec="libx264", 
                     acodec="libvorbis", 
                     pix_fmt="yuv420p", 
-                    crf=18, 
+                    crf=18,
+                    vf=f"subtitles={self.media_path}",
                     **{"metadata:g:0":f"title={self.metadata_title}", 
                     "metadata:g:1":f"season_number={self.metadata_season}", 
                     "metadata:g:2":f"show={self.metadata_showname}",

--- a/clipplexAPI.py
+++ b/clipplexAPI.py
@@ -133,7 +133,7 @@ class Snapshot:
         a = subprocess.call(cmd, shell=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
 
 class Video:
-    def __init__(self, plex_data: PlexInfo, time: str, duration, file_name: str):
+    def __init__(self, plex_data: PlexInfo, time: str, duration, file_name: str, subs: str):
         self.media_path = plex_data.media_path
         plex_attributes = list(list(plex_data.media_path_xml))[0].attrib
         self.metadata_title = plex_attributes["title"]
@@ -151,28 +151,48 @@ class Video:
         self.time = time
         self.duration = duration
         self.file_name = file_name
+        self.subs = subs
 
     def extract_video(self):
-        (
-            ffmpeg
-            .input(self.media_path)
-            .output(f"{MEDIA_STATIC_PATH}/videos/{self.file_name}.mp4",
-                    ss=self.time,
-                    t=self.duration, 
-                    map_metadata=-1, 
-                    vcodec="libx264", 
-                    acodec="libvorbis", 
-                    pix_fmt="yuv420p", 
-                    crf=18,
-                    vf=f"subtitles={self.media_path}",
-                    **{"metadata:g:0":f"title={self.metadata_title}", 
-                    "metadata:g:1":f"season_number={self.metadata_season}", 
-                    "metadata:g:2":f"show={self.metadata_showname}",
-                    "metadata:g:3":f"episode_id={self.metadata_episode_number}",
-                    "metadata:g:4":f"comment={self.metadata_current_media_time}",
-                    "metadata:g:5":f"artist={self.metadata_username}"})
-            .run(capture_stdout=True)
-        )
+        if self.subs=="true":
+            (
+                ffmpeg
+                .input(self.media_path)
+                .output(f"{MEDIA_STATIC_PATH}/videos/{self.file_name}.mp4",
+                        ss=self.time,
+                        t=self.duration, 
+                        map_metadata=-1, 
+                        vcodec="libx264", 
+                        acodec="libvorbis", 
+                        pix_fmt="yuv420p", 
+                        crf=18,
+                        vf=f"subtitles={self.media_path}",
+                        **{"metadata:g:0":f"title={self.metadata_title}", 
+                        "metadata:g:1":f"season_number={self.metadata_season}", 
+                        "metadata:g:2":f"show={self.metadata_showname}",
+                        "metadata:g:3":f"episode_id={self.metadata_episode_number}",
+                        "metadata:g:4":f"comment={self.metadata_current_media_time}",
+                        "metadata:g:5":f"artist={self.metadata_username}"})
+                .run(capture_stdout=True)
+            )
+        else:
+            (
+                ffmpeg
+                .input(self.media_path,ss=self.time,t=self.duration)
+                .output(f"{MEDIA_STATIC_PATH}/videos/{self.file_name}.mp4",
+                        map_metadata=-1, 
+                        vcodec="libx264", 
+                        acodec="libvorbis", 
+                        pix_fmt="yuv420p", 
+                        crf=18,
+                        **{"metadata:g:0":f"title={self.metadata_title}", 
+                        "metadata:g:1":f"season_number={self.metadata_season}", 
+                        "metadata:g:2":f"show={self.metadata_showname}",
+                        "metadata:g:3":f"episode_id={self.metadata_episode_number}",
+                        "metadata:g:4":f"comment={self.metadata_current_media_time}",
+                        "metadata:g:5":f"artist={self.metadata_username}"})
+                .run(capture_stdout=True)
+            )
 
 class Utils:
     def __init__(self, offset: int=0):


### PR DESCRIPTION
Adds extremely basic subtitle functionality.

This basically uses the default subtitle stream of the original video file if toggled on. FFMPEG does seemingly not support seeking with subtitles so the related options need to be added to the output file instead. This means that everything that comes before the clip must be rendered as well. Therefore the disclaimer of "Will take way longer" next to the checkbox.

As basic as it may be, this implementation should cover ~80% of my library and I think it may be the same for many other people.
